### PR TITLE
add serde(skip) for mry when struct derives serde::*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
 name = "js-sys"
 version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +423,8 @@ dependencies = [
  "mry_macros",
  "once_cell",
  "parking_lot",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -426,6 +434,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
+ "serde",
  "similar-asserts",
  "syn",
 ]
@@ -525,11 +534,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -557,10 +566,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "similar"
@@ -606,13 +652,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -626,16 +672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "value-bag"

--- a/mry/Cargo.toml
+++ b/mry/Cargo.toml
@@ -19,3 +19,5 @@ parking_lot = "0.11"
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
 async-trait = "0.1"
+serde = { version = '1', features = ["derive"]}
+serde_json = "1"

--- a/mry/tests/integration/main.rs
+++ b/mry/tests/integration/main.rs
@@ -12,3 +12,4 @@ mod partial_mock;
 mod reference_and_pattern;
 mod simple_case;
 mod static_function;
+mod serde_struct;

--- a/mry/tests/integration/serde_struct.rs
+++ b/mry/tests/integration/serde_struct.rs
@@ -1,0 +1,26 @@
+#[mry::mry]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+struct Cat {
+    name: String,
+}
+
+#[mry::mry]
+impl Cat {
+    fn meow(&self, count: usize) -> String {
+        format!("{}: {}", self.name, "meow".repeat(count))
+    }
+}
+
+
+#[test]
+fn cat_can_serialize() {
+    let cat: Cat = mry::new!(Cat {
+        name: "Tama".into(),
+        ..Default::default()
+    });
+    assert_eq!(cat.meow(2), "Tama: meowmeow".to_string());
+
+    let serialized = serde_json::to_string(&cat);
+    assert!(serialized.is_ok());
+    assert_eq!(serialized.unwrap(), r#"{"name":"Tama"}"#)
+}

--- a/mry_macros/Cargo.toml
+++ b/mry_macros/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["visit", "visit-mut", "full"] }
+syn = { version = "1.0.98", features = ["visit", "visit-mut", "full"] }
 
 [lib]
 proc-macro = true
@@ -21,3 +21,4 @@ proc-macro = true
 [dev-dependencies]
 pretty_assertions = "0.7"
 similar-asserts = "1.1"
+serde = { version = '1', features = ["derive"]}

--- a/mry_macros/src/item_struct.rs
+++ b/mry_macros/src/item_struct.rs
@@ -188,30 +188,6 @@ mod test {
     #[test]
     fn skip_serde() {
         let input: ItemStruct = parse2(quote! {
-            #[derive(serde::Serialize)]
-            struct Cat {
-                pub name: String
-            }
-        })
-        .unwrap();
-
-        assert_eq!(
-            transform(input).to_string(),
-            quote! {
-                #[derive(serde::Serialize)]
-                struct Cat {
-                    pub name: String,
-                    #[serde(skip)]
-                    pub mry : mry::Mry,
-                }
-            }
-            .to_string()
-        );
-    }
-
-    #[test]
-    fn skip_serde_with_use() {
-        let input: ItemStruct = parse2(quote! {
             #[derive(Debug, Clone, PartialEq, serde::Serialize)]
             struct Cat {
                 pub name: String


### PR DESCRIPTION
一旦 serde::* を derive していたら `serde(skip)` をいれた

`use serde::Serialize` して `#[derive(Serialize)]` されたらどうするかは考えられてない
