### PR TITLE
add `#[allow(non_snake_case)]` to function starts with underscore

### DIFF
--- a/mry/tests/integration/main.rs
+++ b/mry/tests/integration/main.rs
@@ -10,6 +10,6 @@ mod nested_mock;
 mod not_clone;
 mod partial_mock;
 mod reference_and_pattern;
+mod serde_struct;
 mod simple_case;
 mod static_function;
-mod serde_struct;

--- a/mry/tests/integration/main.rs
+++ b/mry/tests/integration/main.rs
@@ -10,6 +10,6 @@ mod nested_mock;
 mod not_clone;
 mod partial_mock;
 mod reference_and_pattern;
-mod serde_struct;
 mod simple_case;
 mod static_function;
+mod serde_struct;

--- a/mry/tests/integration/mut_param.rs
+++ b/mry/tests/integration/mut_param.rs
@@ -24,5 +24,8 @@ fn meow_returns_with() {
     cat.mock_meow("aaa".to_string())
         .returns_with(|string| format!("Called with {}", string));
 
-    assert_eq!(cat.meow("aaa".to_string()), "Called with aaa".to_string());
+    assert_eq!(
+        cat.meow("aaa".to_string()),
+        "Called with aaa".to_string()
+    );
 }

--- a/mry/tests/integration/mut_param.rs
+++ b/mry/tests/integration/mut_param.rs
@@ -24,8 +24,5 @@ fn meow_returns_with() {
     cat.mock_meow("aaa".to_string())
         .returns_with(|string| format!("Called with {}", string));
 
-    assert_eq!(
-        cat.meow("aaa".to_string()),
-        "Called with aaa".to_string()
-    );
+    assert_eq!(cat.meow("aaa".to_string()), "Called with aaa".to_string());
 }

--- a/mry/tests/integration/serde_struct.rs
+++ b/mry/tests/integration/serde_struct.rs
@@ -11,7 +11,6 @@ impl Cat {
     }
 }
 
-
 #[test]
 fn cat_can_serialize() {
     let cat: Cat = mry::new!(Cat {

--- a/mry/tests/integration/serde_struct.rs
+++ b/mry/tests/integration/serde_struct.rs
@@ -11,6 +11,7 @@ impl Cat {
     }
 }
 
+
 #[test]
 fn cat_can_serialize() {
     let cat: Cat = mry::new!(Cat {

--- a/mry_macros/src/item_fn.rs
+++ b/mry_macros/src/item_fn.rs
@@ -41,26 +41,26 @@ mod test {
         assert_eq!(
             transform(input).to_string(),
             quote! {
-				fn meow(count: usize) -> String {
+                fn meow(count: usize) -> String {
                     #[cfg(debug_assertions)]
-					if let Some(out) = mry::STATIC_MOCKS.write().record_call_and_find_mock_output(std::any::Any::type_id(&meow), "meow", (count.clone())) {
-						return out;
-					}
-					{
+                    if let Some(out) = mry::STATIC_MOCKS.write().record_call_and_find_mock_output(std::any::Any::type_id(&meow), "meow", (count.clone())) {
+                        return out;
+                    }
+                    {
                         "meow".repeat(count)
                     }
-				}
+                }
 
                 #[cfg(debug_assertions)]
-				pub fn mock_meow<'mry>(count: impl Into<mry::Matcher<usize>>) -> mry::MockLocator<'mry, (usize), String, mry::Behavior1<(usize), String> > {
-					mry::MockLocator {
-						mocks: Box::new(mry::STATIC_MOCKS.write()),
-						key: std::any::Any::type_id(&meow),
-						name: "meow",
-						matcher: Some((count.into(),).into()),
-						_phantom: Default::default(),
-					}
-				}
+                pub fn mock_meow<'mry>(count: impl Into<mry::Matcher<usize>>) -> mry::MockLocator<'mry, (usize), String, mry::Behavior1<(usize), String> > {
+                    mry::MockLocator {
+                        mocks: Box::new(mry::STATIC_MOCKS.write()),
+                        key: std::any::Any::type_id(&meow),
+                        name: "meow",
+                        matcher: Some((count.into(),).into()),
+                        _phantom: Default::default(),
+                    }
+                }
             }
             .to_string()
         );
@@ -78,27 +78,27 @@ mod test {
         assert_eq!(
             transform(input).to_string(),
             quote! {
-				fn _meow(count: usize) -> String {
+                fn _meow(count: usize) -> String {
                     #[cfg(debug_assertions)]
-					if let Some(out) = mry::STATIC_MOCKS.write().record_call_and_find_mock_output(std::any::Any::type_id(&_meow), "_meow", (count.clone())) {
-						return out;
-					}
-					{
+                    if let Some(out) = mry::STATIC_MOCKS.write().record_call_and_find_mock_output(std::any::Any::type_id(&_meow), "_meow", (count.clone())) {
+                        return out;
+                    }
+                    {
                         "meow".repeat(count)
                     }
-				}
+                }
 
                 #[cfg(debug_assertions)]
                 #[allow(non_snake_case)]
-				pub fn mock__meow<'mry>(count: impl Into<mry::Matcher<usize>>) -> mry::MockLocator<'mry, (usize), String, mry::Behavior1<(usize), String> > {
-					mry::MockLocator {
-						mocks: Box::new(mry::STATIC_MOCKS.write()),
-						key: std::any::Any::type_id(&_meow),
-						name: "_meow",
-						matcher: Some((count.into(),).into()),
-						_phantom: Default::default(),
-					}
-				}
+                pub fn mock__meow<'mry>(count: impl Into<mry::Matcher<usize>>) -> mry::MockLocator<'mry, (usize), String, mry::Behavior1<(usize), String> > {
+                    mry::MockLocator {
+                        mocks: Box::new(mry::STATIC_MOCKS.write()),
+                        key: std::any::Any::type_id(&_meow),
+                        name: "_meow",
+                        matcher: Some((count.into(),).into()),
+                        _phantom: Default::default(),
+                    }
+                }
             }
             .to_string()
         );

--- a/mry_macros/src/item_struct.rs
+++ b/mry_macros/src/item_struct.rs
@@ -1,25 +1,25 @@
-use proc_macro2::TokenStream;
 use proc_macro2::TokenTree;
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{visit::Visit, ItemStruct};
+use syn::{ItemStruct, visit::Visit};
 
 #[derive(Default)]
 struct SerdeFindVisitor(bool);
 
 impl<'ast> Visit<'ast> for SerdeFindVisitor {
     fn visit_attribute(&mut self, i: &'ast syn::Attribute) {
-        if i.path.is_ident("derive")
-            && i.tokens.clone().into_iter().any(|t| match t {
-                TokenTree::Group(g) => g.stream().into_iter().any(|s| match s {
-                    TokenTree::Ident(i) => i == "serde",
-                    _ => false,
-                }),
-                _ => false,
+       if i.path.is_ident("derive") && i.tokens.clone().into_iter().any(|t| match t {
+        TokenTree::Group(g) => {
+            g.stream().into_iter().any(|s| match s {
+                TokenTree::Ident(i) => i == "serde",
+                _ => false
             })
-        {
-            self.0 = true
-        };
-    }
+        }
+        _ => false
+       }) {
+        self.0 =true
+    };
+}
 }
 
 pub(crate) fn transform(input: ItemStruct) -> TokenStream {
@@ -27,11 +27,7 @@ pub(crate) fn transform(input: ItemStruct) -> TokenStream {
     let struct_name = &input.ident;
 
     let mut serde_find_visitor = SerdeFindVisitor::default();
-    let _ = &input
-        .attrs
-        .clone()
-        .into_iter()
-        .for_each(|a| serde_find_visitor.visit_attribute(&a));
+    let _ = &input.attrs.clone().into_iter().for_each(|a| serde_find_visitor.visit_attribute(&a));
     let serde_skip_or_blank = if serde_find_visitor.0 {
         quote!(#[serde(skip)])
     } else {

--- a/mry_macros/src/item_trait.rs
+++ b/mry_macros/src/item_trait.rs
@@ -90,14 +90,14 @@ mod test {
         assert_eq!(
             transform(input).to_string(),
             quote! {
-				trait Cat {
-					fn meow(&self, count: usize) -> String;
-				}
+                trait Cat {
+                    fn meow(&self, count: usize) -> String;
+                }
 
-				#[derive(Default, Clone, Debug)]
-				struct MockCat {
-					pub mry : mry::Mry,
-				}
+                #[derive(Default, Clone, Debug)]
+                struct MockCat {
+                    pub mry : mry::Mry,
+                }
 
                 impl Cat for MockCat {
                     fn meow(&self, count: usize) -> String {
@@ -138,14 +138,14 @@ mod test {
         assert_eq!(
             transform(input).to_string(),
             quote! {
-				pub trait Cat {
-					fn meow(&self, count: usize) -> String;
-				}
+                pub trait Cat {
+                    fn meow(&self, count: usize) -> String;
+                }
 
-				#[derive(Default, Clone, Debug)]
-				pub struct MockCat {
-					pub mry : mry::Mry,
-				}
+                #[derive(Default, Clone, Debug)]
+                pub struct MockCat {
+                    pub mry : mry::Mry,
+                }
 
                 impl Cat for MockCat {
                     fn meow(&self, count: usize) -> String {
@@ -188,14 +188,14 @@ mod test {
             transform(input).to_string(),
             quote! {
                 #[async_trait::async_trait]
-				trait Cat {
-					async fn meow(&self, count: usize) -> String;
-				}
+                trait Cat {
+                    async fn meow(&self, count: usize) -> String;
+                }
 
-				#[derive(Default, Clone, Debug)]
-				struct MockCat {
-					pub mry : mry::Mry,
-				}
+                #[derive(Default, Clone, Debug)]
+                struct MockCat {
+                    pub mry : mry::Mry,
+                }
 
                 #[async_trait::async_trait]
                 impl Cat for MockCat {
@@ -237,14 +237,14 @@ mod test {
         assert_eq!(
             transform(input).to_string(),
             quote! {
-				trait Cat {
-					fn _meow(&self, count: usize) -> String;
-				}
+                trait Cat {
+                    fn _meow(&self, count: usize) -> String;
+                }
 
-				#[derive(Default, Clone, Debug)]
-				struct MockCat {
-					pub mry : mry::Mry,
-				}
+                #[derive(Default, Clone, Debug)]
+                struct MockCat {
+                    pub mry : mry::Mry,
+                }
 
                 impl Cat for MockCat {
                     fn _meow(&self, count: usize) -> String {

--- a/mry_macros/src/method.rs
+++ b/mry_macros/src/method.rs
@@ -451,13 +451,13 @@ mod test {
         assert_eq!(
             t(&input).to_string(),
             quote! {
-				fn meow(&self, arg0: A, count: usize, arg2: String) -> String {
+                fn meow(&self, arg0: A, count: usize, arg2: String) -> String {
                     #[cfg(debug_assertions)]
                     if let Some(out) = self.mry.record_call_and_find_mock_output(std::any::Any::type_id(&Self::meow), "Cat::meow", (arg0.clone(), count.clone(), arg2.clone())) {
                         return out;
                     }
-					let A { name } = arg0;
-					let _ = arg2;
+                    let A { name } = arg0;
+                    let _ = arg2;
                     name.repeat(count)
                 }
 


### PR DESCRIPTION
Closes #7 

And replace all tabs to spaces, apply `cargo fmt`.