### PR TITLE
allow more than 5 arguments to instrumented methods

### DIFF
--- a/mry/tests/integration/main.rs
+++ b/mry/tests/integration/main.rs
@@ -7,6 +7,7 @@ mod function_style_macro;
 mod generics;
 mod impl_trait;
 mod iterator;
+mod many_arguments;
 mod mock_trait;
 mod mut_param;
 mod nested_mock;

--- a/mry/tests/integration/many_arguments.rs
+++ b/mry/tests/integration/many_arguments.rs
@@ -1,0 +1,52 @@
+use mry::Any;
+
+#[mry::mry]
+#[derive(Default, PartialEq)]
+struct Cat {
+    name: String,
+}
+
+#[mry::mry]
+impl Cat {
+    fn meow(
+        &self,
+        count_part1: usize,
+        count_part2: usize,
+        count_part3: usize,
+        count_part4: usize,
+        count_part5: usize,
+        count_part6: usize,
+        count_part7: usize,
+        count_part8: usize,
+        count_part9: usize,
+    ) -> String {
+        format!(
+            "{}: {}",
+            self.name,
+            "meow".repeat(
+                count_part1
+                    + count_part2
+                    + count_part3
+                    + count_part4
+                    + count_part5
+                    + count_part6
+                    + count_part7
+                    + count_part8
+                    + count_part9
+            )
+        )
+    }
+}
+
+#[test]
+fn many_arguments() {
+    let mut cat: Cat = mry::new!(Cat {
+        name: "Tama".into(),
+        ..Default::default()
+    });
+    let mock = cat
+        .mock_meow(Any, Any, Any, Any, Any, Any, Any, Any, Any)
+        .returns("something".to_string());
+    assert_eq!(cat.meow(2, 2, 2, 2, 2, 2, 2, 2, 2), "something".to_string());
+    mock.assert_called(1)
+}

--- a/mry_macros/src/alphabets.rs
+++ b/mry_macros/src/alphabets.rs
@@ -1,8 +1,0 @@
-use std::ops::Range;
-
-pub(crate) fn alphabets(range: Range<usize>) -> impl Iterator<Item = Vec<&'static str>> {
-    let alphabet = ["A", "B", "C", "D", "E", "F", "G", "H"];
-    range
-        .into_iter()
-        .map(move |index| alphabet[0..index].to_vec())
-}

--- a/mry_macros/src/create_behaviors.rs
+++ b/mry_macros/src/create_behaviors.rs
@@ -2,16 +2,16 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::Ident;
 
-use crate::alphabets::alphabets;
+use crate::MAX_ARGUMENT_COUNT;
 
 pub fn create() -> TokenStream {
-    let items = alphabets(0..6).map(|args| {
-        let (args, types): (Vec<_>, Vec<_>) = args
-            .iter()
-            .map(|name| {
+    let items = (0..=MAX_ARGUMENT_COUNT).map(|nargs| {
+        let (args, types): (Vec<_>, Vec<_>) = (1..=nargs)
+            .map(|i| {
+                let name = format!("Arg{i}");
                 (
                     Ident::new(&name.to_lowercase(), Span::call_site()),
-                    Ident::new(name, Span::call_site()),
+                    Ident::new(&name, Span::call_site()),
                 )
             })
             .unzip();

--- a/mry_macros/src/create_matchers.rs
+++ b/mry_macros/src/create_matchers.rs
@@ -2,16 +2,16 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{Ident, Index};
 
-use crate::alphabets::alphabets;
+use crate::MAX_ARGUMENT_COUNT;
 
 pub(crate) fn create() -> TokenStream {
-    let items = alphabets(0..6).map(|args| {
-        let (args, types): (Vec<_>, Vec<_>) = args
-            .iter()
-            .map(|name| {
+    let items = (0..=MAX_ARGUMENT_COUNT).map(|nargs| {
+        let (args, types): (Vec<_>, Vec<_>) = (1..=nargs)
+            .map(|i| {
+                let name = format!("Arg{i}");
                 (
                     Ident::new(&name.to_lowercase(), Span::call_site()),
-                    Ident::new(name, Span::call_site()),
+                    Ident::new(&name, Span::call_site()),
                 )
             })
             .unzip();

--- a/mry_macros/src/lib.rs
+++ b/mry_macros/src/lib.rs
@@ -13,8 +13,10 @@ use lock::LockPaths;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::visit_mut::VisitMut;
-mod alphabets;
 use syn::{parse, parse2, parse_macro_input, ExprStruct, ItemFn, ItemImpl, ItemStruct, ItemTrait};
+
+/// functions may not be instrumented if they take more than this number of arguments
+const MAX_ARGUMENT_COUNT: u32 = 10;
 
 enum TargetItem {
     Struct(ItemStruct),


### PR DESCRIPTION
For more flexibility, use type arguments in the form `Arg{n}` instead of a letter of the alphabet.

Centralize the maximum number of arguments in a constant.