### PR TITLE
feat: add possibility to mock non-Send types like raw pointers

### DIFF
--- a/mry/src/lib.rs
+++ b/mry/src/lib.rs
@@ -5,11 +5,12 @@ mod mocks;
 mod mry;
 mod rule;
 mod static_mocks;
+pub mod unsafe_mocks;
 
 pub use crate::mry::*;
 pub use mock_locator::*;
 pub use mocks::*;
-pub use mry_macros::{lock, m, mry, new};
+pub use mry_macros::{lock, m, mry, new, unsafe_lock, unsafe_mry};
 pub use rule::*;
 pub use static_mocks::*;
 

--- a/mry/src/unsafe_mocks/behavior.rs
+++ b/mry/src/unsafe_mocks/behavior.rs
@@ -1,0 +1,122 @@
+use std::{cell::RefCell, fmt::Debug};
+
+use crate::Output;
+
+/// Behavior of mock
+pub enum UnsafeBehavior<I, O> {
+    /// Behaves with a function
+    Function {
+        clone: fn(&I) -> I,
+        call: Box<dyn FnMut(I) -> O + 'static>,
+    },
+    /// Returns a constant value
+    Const(RefCell<Box<dyn Iterator<Item = O> + 'static>>),
+    /// Once
+    Once(RefCell<Option<O>>),
+    /// Calls real implementation instead of mock
+    CallsRealImpl,
+}
+
+impl<I: Debug, O: Debug> std::fmt::Debug for UnsafeBehavior<I, O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Function { .. } => f.debug_tuple("Function(_)").finish(),
+            Self::Const(cons) => f
+                .debug_tuple("Const")
+                .field(&cons.borrow_mut().next().unwrap())
+                .finish(),
+            Self::Once(once) => f
+                .debug_tuple("Once")
+                .field(&once.borrow().as_ref().unwrap())
+                .finish(),
+            Self::CallsRealImpl => write!(f, "CallsRealImpl"),
+        }
+    }
+}
+
+impl<I, O> UnsafeBehavior<I, O> {
+    pub(crate) fn called(&mut self, input: &I) -> Output<O> {
+        match self {
+            UnsafeBehavior::Function { clone, call } => Output::Found(call(clone(input))),
+            UnsafeBehavior::Const(cons) => Output::Found(cons.get_mut().next().unwrap()),
+            UnsafeBehavior::Once(once) => {
+                if let Some(ret) = once.take() {
+                    Output::Found(ret)
+                } else {
+                    Output::ErrorCalledOnce
+                }
+            }
+            UnsafeBehavior::CallsRealImpl => Output::CallsRealImpl,
+        }
+    }
+}
+
+mry_macros::unsafe_create_behaviors!();
+
+#[cfg(test)]
+mod tests {
+    use std::iter::repeat;
+
+    use super::*;
+
+    #[test]
+    fn function() {
+        assert_eq!(
+            UnsafeBehavior::Function {
+                call: Box::new(|()| "aaa"),
+                clone: Clone::clone
+            }
+            .called(&()),
+            Output::Found("aaa")
+        );
+    }
+
+    #[test]
+    fn const_value() {
+        assert_eq!(
+            UnsafeBehavior::Const(RefCell::new(Box::new(repeat("aaa")))).called(&()),
+            Output::Found("aaa")
+        );
+    }
+
+    #[test]
+    fn calls_real_impl() {
+        assert_eq!(
+            UnsafeBehavior::<_, ()>::CallsRealImpl.called(&()),
+            Output::CallsRealImpl
+        );
+    }
+
+    #[test]
+    fn debug_calls_real_impl() {
+        assert_eq!(
+            format!("{:?}", UnsafeBehavior::<u8, u8>::CallsRealImpl),
+            "CallsRealImpl".to_string()
+        )
+    }
+
+    #[test]
+    fn debug_const() {
+        assert_eq!(
+            format!(
+                "{:?}",
+                UnsafeBehavior::<u8, u8>::Const(RefCell::new(Box::new(repeat(3))))
+            ),
+            "Const(3)".to_string()
+        )
+    }
+
+    #[test]
+    fn debug_function() {
+        assert_eq!(
+            format!(
+                "{:?}",
+                UnsafeBehavior::<u8, u8>::Function {
+                    clone: Clone::clone,
+                    call: Box::new(|a| a)
+                }
+            ),
+            "Function(_)".to_string()
+        )
+    }
+}

--- a/mry/src/unsafe_mocks/locator.rs
+++ b/mry/src/unsafe_mocks/locator.rs
@@ -1,0 +1,99 @@
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::rc::Rc;
+use std::{any::TypeId, cell::RefCell};
+
+use crate::times::Times;
+
+use super::behavior::UnsafeBehavior;
+use super::matcher::UnsafeMatcher;
+use super::{UnsafeMockGetter, UnsafeMockableRet};
+
+/// Mock locator returned by mock_* methods
+pub struct UnsafeMockLocator<I, O, B> {
+    pub(crate) mocks: Rc<RefCell<dyn UnsafeMockGetter<I, O>>>,
+    pub(crate) key: TypeId,
+    pub(crate) name: &'static str,
+    pub(crate) matcher: Rc<RefCell<UnsafeMatcher<I>>>,
+    #[allow(clippy::type_complexity)]
+    _phantom: PhantomData<fn() -> (I, O, B)>,
+}
+
+impl<I, O, B> UnsafeMockLocator<I, O, B> {
+    #[doc(hidden)]
+    pub fn new(
+        mocks: Rc<RefCell<dyn UnsafeMockGetter<I, O>>>,
+        key: TypeId,
+        name: &'static str,
+        matcher: UnsafeMatcher<I>,
+    ) -> Self {
+        Self {
+            mocks,
+            key,
+            name,
+            matcher: Rc::new(RefCell::new(matcher)),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+macro_rules! get_mut_or_default {
+    ($self:ident) => {
+        $self
+            .mocks
+            .borrow_mut()
+            .get_mut_or_create($self.key, $self.name)
+    };
+}
+
+impl<I, O, B> UnsafeMockLocator<I, O, B>
+where
+    I: 'static,
+    O: 'static,
+    B: Into<UnsafeBehavior<I, O>>,
+{
+    /// Returns value with using a closure.
+    /// Arguments of a method call are passed to the given closure.
+    pub fn returns_with<T: Into<B>>(self, behavior: T) -> Self {
+        get_mut_or_default!(self).returns_with(self.matcher.clone(), behavior.into().into());
+        self
+    }
+
+    /// Returns value once. After that, it panics.
+    pub fn returns_once(self, ret: O) -> Self {
+        get_mut_or_default!(self).returns_once(self.matcher.clone(), ret);
+        self
+    }
+}
+
+impl<I, O, B> UnsafeMockLocator<I, O, B>
+where
+    I: 'static,
+    O: 'static,
+{
+    /// This make the mock calls real impl. This is used for partial mocking.
+    pub fn calls_real_impl(self) -> Self {
+        get_mut_or_default!(self).calls_real_impl(self.matcher.clone());
+        self
+    }
+
+    /// Assert the mock is called.
+    /// Returns `MockResult` allows to call `times(n)`
+    /// Panics if not called
+    pub fn assert_called(&self, times: impl Into<Times>) {
+        get_mut_or_default!(self).assert_called(self.matcher.borrow().deref(), times.into());
+    }
+}
+
+impl<I, O, B> UnsafeMockLocator<I, O, B>
+where
+    I: 'static,
+    O: Clone + UnsafeMockableRet,
+{
+    /// This makes the mock returns the given constant value.
+    /// This requires `Clone`. For returning not clone value, use `returns_once`.
+    pub fn returns(self, ret: O) -> Self {
+        get_mut_or_default!(self).returns(self.matcher.clone(), ret);
+        self
+    }
+}

--- a/mry/src/unsafe_mocks/log.rs
+++ b/mry/src/unsafe_mocks/log.rs
@@ -1,0 +1,69 @@
+use std::{cell::RefCell, ops::Deref, rc::Rc};
+
+use crate::times::Times;
+
+use super::matcher::UnsafeMatcher;
+
+pub struct UnsafeLogs<I>(Vec<Rc<RefCell<I>>>);
+
+impl<I: 'static> UnsafeLogs<I> {
+    pub(crate) fn push(&mut self, item: Rc<RefCell<I>>) {
+        self.0.push(item);
+    }
+
+    pub fn filter_matches(&self, matcher: &UnsafeMatcher<I>) -> Self {
+        Self(
+            self.0
+                .iter()
+                .filter(|log| matcher.matches(&log.borrow()))
+                .cloned()
+                .collect(),
+        )
+    }
+
+    pub(crate) fn assert_called(
+        &self,
+        name: &str,
+        matcher: &UnsafeMatcher<I>,
+        times: Times,
+    ) -> Self {
+        let logs = self.filter_matches(matcher);
+        let actual = logs.0.len();
+        if !times.contains(&actual) {
+            panic!(
+                "Expected {} to be called {} times, but it was called {} times",
+                name, times, actual,
+            );
+        }
+        logs
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = impl Deref<Target = I> + '_> {
+        self.0.iter().map(|log| log.borrow())
+    }
+}
+
+impl<I> Default for UnsafeLogs<I> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn filter_matches() {
+        let mut logs = UnsafeLogs::default();
+        logs.push(Rc::new(RefCell::new(1)));
+        logs.push(Rc::new(RefCell::new(2)));
+        logs.push(Rc::new(RefCell::new(3)));
+        logs.push(Rc::new(RefCell::new(2)));
+
+        let matcher = UnsafeMatcher::new_eq(2);
+
+        let filtered = logs.filter_matches(&matcher);
+        assert_eq!(filtered.0.len(), 2);
+    }
+}

--- a/mry/src/unsafe_mocks/matcher.rs
+++ b/mry/src/unsafe_mocks/matcher.rs
@@ -1,0 +1,163 @@
+#[cfg(test)]
+use std::{cell::RefCell, rc::Rc};
+
+use super::mockable::UnsafeMockableArg;
+
+pub trait UnsafeMatch<I> {
+    fn matches(&self, input: &I) -> bool;
+}
+
+/// An enum describes what arguments are expected
+pub struct UnsafeMatcher<I>(Box<dyn UnsafeMatch<I>>);
+
+impl<I> UnsafeMatcher<I> {
+    #[cfg(test)]
+    pub(crate) fn wrapped(self) -> Rc<RefCell<UnsafeMatcher<I>>> {
+        use std::{cell::RefCell, rc::Rc};
+
+        Rc::new(RefCell::new(self))
+    }
+
+    pub(crate) fn matches(&self, input: &I) -> bool {
+        self.0.matches(input)
+    }
+}
+
+#[cfg(test)]
+impl<I> UnsafeMatcher<I> {
+    pub(crate) fn from_match(matcher: impl UnsafeMatch<I> + 'static) -> Self {
+        Self(Box::new(matcher))
+    }
+
+    pub(crate) fn any() -> Self {
+        struct Any;
+        impl<I> UnsafeMatch<I> for Any {
+            fn matches(&self, _: &I) -> bool {
+                true
+            }
+        }
+        Self::from_match(Any)
+    }
+
+    pub(crate) fn never() -> Self {
+        struct Never;
+        impl<I> UnsafeMatch<I> for Never {
+            fn matches(&self, _: &I) -> bool {
+                false
+            }
+        }
+        Self::from_match(Never)
+    }
+}
+
+pub enum UnsafeArgMatcher<I> {
+    Fn(Box<dyn Fn(&I) -> bool + 'static>),
+    Eq {
+        value: I,
+        partial_eq: fn(&I, &I) -> bool,
+    },
+    Any,
+    Never,
+}
+
+impl<I> UnsafeArgMatcher<I> {
+    pub(crate) fn new_eq(value: I) -> Self
+    where
+        I: PartialEq + UnsafeMockableArg,
+    {
+        UnsafeArgMatcher::Fn(Box::new(move |input| *input == value))
+    }
+
+    pub(crate) fn matches(&self, input: &I) -> bool {
+        match self {
+            UnsafeArgMatcher::Fn(f) => f(input),
+            UnsafeArgMatcher::Eq { value, partial_eq } => partial_eq(value, input),
+            UnsafeArgMatcher::Any => true,
+            UnsafeArgMatcher::Never => false,
+        }
+    }
+}
+
+impl<I: PartialEq + UnsafeMockableArg> From<I> for UnsafeArgMatcher<I> {
+    fn from(value: I) -> Self {
+        UnsafeArgMatcher::new_eq(value)
+    }
+}
+
+impl From<&str> for UnsafeArgMatcher<String> {
+    fn from(value: &str) -> Self {
+        UnsafeArgMatcher::new_eq(value.to_string())
+    }
+}
+
+impl<'a, O: PartialEq + UnsafeMockableArg, I> From<&'a [I]> for UnsafeArgMatcher<Vec<O>>
+where
+    I: Into<UnsafeArgMatcher<O>> + Clone,
+{
+    fn from(value: &'a [I]) -> Self {
+        let cloned: Vec<UnsafeArgMatcher<O>> = value
+            .iter()
+            .map(|elem| -> UnsafeArgMatcher<O> { elem.clone().into() })
+            .collect();
+        let check = move |actual: &Vec<O>| {
+            if actual.len() != cloned.len() {
+                return false;
+            }
+            for (cloned_item, actual_item) in cloned.iter().zip(actual.iter()) {
+                if !cloned_item.matches(actual_item) {
+                    return false;
+                }
+            }
+            true
+        };
+        UnsafeArgMatcher::Fn(Box::new(check))
+    }
+}
+
+impl<'a, O: PartialEq + UnsafeMockableArg, I, const N: usize> From<&'a [I; N]>
+    for UnsafeArgMatcher<Vec<O>>
+where
+    I: Into<UnsafeArgMatcher<O>> + Clone,
+{
+    fn from(value: &'a [I; N]) -> Self {
+        <&'a [I]>::into(&value[..])
+    }
+}
+
+mry_macros::unsafe_create_matchers!();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct EqMatcher<T>(T);
+
+    impl<T: PartialEq> UnsafeMatch<T> for EqMatcher<T> {
+        fn matches(&self, input: &T) -> bool {
+            self.0 == *input
+        }
+    }
+
+    impl<T: PartialEq + Send + 'static> UnsafeMatcher<T> {
+        pub(crate) fn new_eq(value: T) -> Self {
+            Self(Box::new(EqMatcher(value)))
+        }
+    }
+
+    #[test]
+    fn from_str() {
+        let matcher: UnsafeArgMatcher<String> = "A".to_string().into();
+        assert!(matcher.matches(&"A".to_string()));
+        assert!(!matcher.matches(&"B".to_string()));
+    }
+
+    #[test]
+    fn matcher_two_values() {
+        let matcher: UnsafeMatcher<(u8, u16)> =
+            UnsafeMatcher::from_match((3u8.into(), 2u16.into()));
+        assert!(matcher.matches(&(3, 2)));
+        assert!(!matcher.matches(&(3, 1)));
+        assert!(!matcher.matches(&(1, 2)));
+        assert!(!matcher.matches(&(1, 1)));
+    }
+}

--- a/mry/src/unsafe_mocks/mock.rs
+++ b/mry/src/unsafe_mocks/mock.rs
@@ -1,0 +1,181 @@
+use std::{cell::RefCell, iter::repeat, rc::Rc};
+
+use crate::{times::Times, Output};
+
+use super::{
+    behavior::UnsafeBehavior, log::UnsafeLogs, matcher::UnsafeMatcher, mockable::UnsafeMockableRet,
+    rule::UnsafeRule,
+};
+
+pub struct UnsafeMock<I, O> {
+    pub name: &'static str,
+    pub log: UnsafeLogs<I>,
+    rules: Vec<UnsafeRule<I, O>>,
+}
+
+impl<I, O> UnsafeMock<I, O> {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            log: Default::default(),
+            rules: Default::default(),
+        }
+    }
+}
+
+impl<I, O> UnsafeMock<I, O> {
+    pub(crate) fn returns_with(
+        &mut self,
+        matcher: Rc<RefCell<UnsafeMatcher<I>>>,
+        behavior: UnsafeBehavior<I, O>,
+    ) {
+        self.rules.push(UnsafeRule { matcher, behavior });
+    }
+
+    pub(crate) fn returns_once(&mut self, matcher: Rc<RefCell<UnsafeMatcher<I>>>, ret: O) {
+        self.returns_with(matcher, UnsafeBehavior::Once(RefCell::new(Some(ret))))
+    }
+
+    pub(crate) fn calls_real_impl(&mut self, matcher: Rc<RefCell<UnsafeMatcher<I>>>) {
+        self.rules.push(UnsafeRule {
+            matcher,
+            behavior: UnsafeBehavior::CallsRealImpl,
+        })
+    }
+}
+
+impl<I: 'static, O> UnsafeMock<I, O> {
+    pub(crate) fn assert_called(&self, matcher: &UnsafeMatcher<I>, times: Times) {
+        self.log.assert_called(self.name, matcher, times);
+    }
+
+    pub(crate) fn record_call(&mut self, input: Rc<RefCell<I>>) {
+        self.log.push(input);
+    }
+}
+
+impl<I, O> UnsafeMock<I, O> {
+    pub(crate) fn find_mock_output(&mut self, input: &I) -> Option<O> {
+        for rule in &mut self.rules {
+            if !rule.matches(input) {
+                continue;
+            }
+            return match rule.call_behavior(input) {
+                Output::Found(output) => Some(output),
+                Output::CallsRealImpl => None,
+                Output::ErrorCalledOnce => {
+                    panic!("{} was called more than once", self.name)
+                }
+            };
+        }
+        panic!("mock not found for {}", self.name)
+    }
+}
+
+impl<I, O> UnsafeMock<I, O>
+where
+    I: 'static,
+    O: Clone + UnsafeMockableRet,
+{
+    pub(crate) fn returns(&mut self, matcher: Rc<RefCell<UnsafeMatcher<I>>>, ret: O) {
+        self.returns_with(
+            matcher,
+            UnsafeBehavior::Const(RefCell::new(Box::new(repeat(ret)))),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::unsafe_mocks::behavior::UnsafeBehavior1;
+
+    #[test]
+    fn returns_with() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns_with(
+            UnsafeMatcher::any().wrapped(),
+            UnsafeBehavior1::from(|a| "a".repeat(a)).into(),
+        );
+
+        assert_eq!(mock.find_mock_output(&(3,)), "aaa".to_string().into());
+    }
+
+    #[test]
+    fn returns() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns(UnsafeMatcher::any().wrapped(), "a".repeat(3));
+
+        assert_eq!(mock.find_mock_output(&(3,)), "aaa".to_string().into());
+
+        // allows called multiple times
+        assert_eq!(mock.find_mock_output(&(3,)), "aaa".to_string().into());
+    }
+
+    #[test]
+    #[should_panic(expected = "mock not found for a")]
+    fn returns_with_never() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns_with(
+            UnsafeMatcher::never().wrapped(),
+            UnsafeBehavior1::from(|a| "a".repeat(a)).into(),
+        );
+
+        mock.find_mock_output(&(3,));
+    }
+
+    #[test]
+    fn returns_with_always() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns_with(
+            UnsafeMatcher::any().wrapped(),
+            UnsafeBehavior1::from(|a| "a".repeat(a)).into(),
+        );
+
+        assert_eq!(mock.find_mock_output(&(3,)), "aaa".to_string().into());
+    }
+
+    #[test]
+    #[should_panic(expected = "mock not found for a")]
+    fn returns_never() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns(UnsafeMatcher::never().wrapped(), "a".repeat(3));
+
+        mock.find_mock_output(&(3,));
+    }
+
+    #[test]
+    fn returns_always() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns(UnsafeMatcher::any().wrapped(), "a".repeat(3));
+
+        assert_eq!(mock.find_mock_output(&(3,)), "aaa".to_string().into());
+    }
+
+    #[test]
+    fn calls_real_impl() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.calls_real_impl(Rc::new(RefCell::new(UnsafeMatcher::new_eq((3,)))));
+
+        assert_eq!(mock.find_mock_output(&(3,)), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "mock not found for a")]
+    fn calls_real_impl_never() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.calls_real_impl(Rc::new(RefCell::new(UnsafeMatcher::new_eq((3,)))));
+
+        mock.find_mock_output(&(2,));
+    }
+
+    #[test]
+    #[should_panic(expected = "a was called more than once")]
+    fn panic_on_once_called_multiple_time() {
+        let mut mock = UnsafeMock::<(usize,), String>::new("a");
+        mock.returns_once(UnsafeMatcher::any().wrapped(), "a".repeat(3));
+
+        mock.find_mock_output(&(3,));
+        mock.find_mock_output(&(3,));
+    }
+}

--- a/mry/src/unsafe_mocks/mockable.rs
+++ b/mry/src/unsafe_mocks/mockable.rs
@@ -1,0 +1,24 @@
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not mockable argument because it is not `'static`",
+    // note = "If you don't need to mock this argument, you can add it to the skip list: `#[mry::mry(skip({Self}))]`"
+)]
+pub trait UnsafeMockableArg: 'static {}
+
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not mockable output because it is not `'static`",
+    // note = "If you don't need to mock this argument, you can add it to the skip list: `#[mry::mry(skip({Self}))]`"
+)]
+pub trait UnsafeMockableRet: 'static {}
+
+impl<T: 'static> UnsafeMockableArg for T {}
+
+impl<T: 'static> UnsafeMockableRet for T {}
+
+pub fn assert_mockable<T: UnsafeMockableArg>(arg: T) -> T {
+    arg
+}
+
+#[test]
+fn a() {
+    assert_mockable::<&str>("a");
+}

--- a/mry/src/unsafe_mocks/mocks.rs
+++ b/mry/src/unsafe_mocks/mocks.rs
@@ -1,0 +1,138 @@
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+use super::mock::UnsafeMock;
+use super::mockable::{UnsafeMockableArg, UnsafeMockableRet};
+
+type BoxAny = Box<dyn Any>;
+
+#[doc(hidden)]
+pub trait UnsafeMockGetter<I, O> {
+    fn get(&self, key: &TypeId, name: &'static str) -> Option<&UnsafeMock<I, O>>;
+    fn get_mut_or_create(&mut self, key: TypeId, name: &'static str) -> &mut UnsafeMock<I, O>;
+}
+
+impl<I, O, T, M: 'static> UnsafeMockGetter<I, O> for T
+where
+    T: DerefMut<Target = M> + Deref<Target = M>,
+    M: UnsafeMockGetter<I, O>,
+{
+    fn get<'a>(&'a self, key: &TypeId, name: &'static str) -> Option<&'a UnsafeMock<I, O>> {
+        self.deref().get(key, name)
+    }
+
+    fn get_mut_or_create(&mut self, key: TypeId, name: &'static str) -> &mut UnsafeMock<I, O> {
+        self.deref_mut().get_mut_or_create(key, name)
+    }
+}
+
+#[derive(Default)]
+#[doc(hidden)]
+pub struct UnsafeMocks {
+    pub(crate) mock_objects: HashMap<TypeId, BoxAny>,
+}
+
+impl<I: UnsafeMockableArg, O: UnsafeMockableRet> UnsafeMockGetter<I, O> for UnsafeMocks {
+    fn get(&self, key: &TypeId, _name: &'static str) -> Option<&UnsafeMock<I, O>> {
+        self.mock_objects
+            .get(key)
+            .map(|mock| mock.downcast_ref().unwrap())
+    }
+
+    fn get_mut_or_create(&mut self, key: TypeId, name: &'static str) -> &mut UnsafeMock<I, O> {
+        self.mock_objects
+            .entry(key)
+            .or_insert(Box::new(UnsafeMock::<I, O>::new(name)))
+            .downcast_mut()
+            .unwrap()
+    }
+}
+
+impl UnsafeMocks {
+    #[doc(hidden)]
+    pub fn record_call_and_find_mock_output<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        &mut self,
+        key: TypeId,
+        name: &'static str,
+        input: I,
+    ) -> Option<O> {
+        let mock = self.get_mut_or_create(key, name);
+        let result = mock.find_mock_output(&input);
+        mock.record_call(Rc::new(RefCell::new(input)));
+        result
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        &mut self,
+        key: TypeId,
+        item: UnsafeMock<I, O>,
+    ) {
+        self.mock_objects.insert(key, Box::new(item));
+    }
+
+    pub(crate) fn remove(&mut self, key: &TypeId) -> Option<()> {
+        self.mock_objects.remove(key).map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::unsafe_mocks::{behavior::UnsafeBehavior, matcher::UnsafeMatcher};
+
+    use super::*;
+
+    #[test]
+    fn get_returns_none() {
+        let mock_data = UnsafeMocks::default();
+        assert!(
+            UnsafeMockGetter::<usize, usize>::get(&mock_data, &TypeId::of::<usize>(), "meow")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn get_returns_an_item() {
+        let mut mock_data = UnsafeMocks::default();
+        mock_data.insert(TypeId::of::<usize>(), UnsafeMock::<usize, usize>::new(""));
+        assert!(
+            UnsafeMockGetter::<usize, usize>::get(&mock_data, &TypeId::of::<usize>(), "name")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn get_mut_or_create_returns_an_item() {
+        let mut mock_data = UnsafeMocks::default();
+        let mut mock = UnsafeMock::<u8, u8>::new("a");
+        mock.returns_with(
+            UnsafeMatcher::any().wrapped(),
+            UnsafeBehavior::Function {
+                call: Box::new(|_| 4u8),
+                clone: Clone::clone,
+            },
+        );
+        mock_data.insert(TypeId::of::<usize>(), mock);
+        assert_eq!(
+            mock_data
+                .get_mut_or_create(TypeId::of::<usize>(), "meow")
+                .find_mock_output(&1u8),
+            Some(4u8)
+        );
+    }
+
+    #[test]
+    // should not panic
+    fn get_mut_or_create_returns_default() {
+        let mut mock_data = UnsafeMocks::default();
+
+        UnsafeMockGetter::<usize, usize>::get_mut_or_create(
+            &mut mock_data,
+            TypeId::of::<usize>(),
+            "meow",
+        );
+    }
+}

--- a/mry/src/unsafe_mocks/mod.rs
+++ b/mry/src/unsafe_mocks/mod.rs
@@ -1,0 +1,19 @@
+mod behavior;
+mod locator;
+mod log;
+mod matcher;
+mod mock;
+mod mockable;
+mod mocks;
+mod mry;
+mod rule;
+mod static_mocks;
+
+pub use behavior::*;
+pub use locator::*;
+pub use matcher::UnsafeArgMatcher::Any;
+pub use matcher::*;
+pub use mockable::*;
+pub use mocks::*;
+pub use mry::*;
+pub use static_mocks::*;

--- a/mry/src/unsafe_mocks/mry.rs
+++ b/mry/src/unsafe_mocks/mry.rs
@@ -1,0 +1,258 @@
+use super::mockable::UnsafeMockableArg;
+use super::mockable::UnsafeMockableRet;
+
+use std::any::TypeId;
+use std::cell::Cell;
+#[cfg(debug_assertions)]
+use std::cell::RefCell;
+use std::cmp::Ordering;
+#[cfg(debug_assertions)]
+use std::rc::Rc;
+
+#[cfg(debug_assertions)]
+use super::UnsafeMockGetter;
+#[cfg(debug_assertions)]
+use super::UnsafeMocks;
+
+/// A unique id for an object
+pub type MryId = u16;
+
+thread_local! {
+    #[cfg(debug_assertions)]
+    static ID: Cell<u16> = Cell::new(0);
+}
+
+#[derive(Clone)]
+/// Mock container that has blank and harmless trait implementation for major traits such as `Eq` and `Ord`
+pub struct UnsafeMry {
+    #[cfg(debug_assertions)]
+    id: MryId,
+    #[cfg(debug_assertions)]
+    mocks: Option<Rc<RefCell<UnsafeMocks>>>,
+}
+
+impl std::fmt::Debug for UnsafeMry {
+    #[cfg(debug_assertions)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mry").field("id", &self.id).finish()
+    }
+    #[cfg(not(debug_assertions))]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mry").finish()
+    }
+}
+
+impl UnsafeMry {
+    #[cfg(debug_assertions)]
+    pub(crate) fn generate(&mut self) -> &mut Self {
+        self.mocks
+            .get_or_insert(Rc::new(RefCell::new(Default::default())));
+        self
+    }
+
+    #[doc(hidden)]
+    #[cfg(debug_assertions)]
+    pub fn record_call_and_find_mock_output<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        &self,
+        key: TypeId,
+        name: &'static str,
+        input: I,
+    ) -> Option<O> {
+        self.mocks.as_ref().and_then(|mocks| {
+            mocks
+                .borrow_mut()
+                .record_call_and_find_mock_output(key, name, input)
+        })
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn record_call_and_find_mock_output<
+        I: PartialEq + std::fmt::Debug + Clone + 'static,
+        O: std::fmt::Debug + 'static,
+    >(
+        &self,
+        _key: TypeId,
+        _name: &'static str,
+        _input: I,
+    ) -> Option<O> {
+        None
+    }
+
+    #[doc(hidden)]
+    #[cfg(debug_assertions)]
+    pub fn mocks<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        &mut self,
+    ) -> Rc<RefCell<dyn UnsafeMockGetter<I, O>>> {
+        self.generate().mocks.as_ref().unwrap().clone()
+    }
+}
+
+impl Default for UnsafeMry {
+    #[cfg(debug_assertions)]
+    fn default() -> Self {
+        Self {
+            id: ID.replace(ID.get() + 1),
+            mocks: None,
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl PartialOrd for UnsafeMry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for UnsafeMry {
+    fn assert_receiver_is_total_eq(&self) {}
+}
+
+impl Ord for UnsafeMry {
+    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
+        Ordering::Equal
+    }
+}
+
+impl std::hash::Hash for UnsafeMry {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&None as &Option<MryId>, state);
+    }
+}
+
+impl PartialEq for UnsafeMry {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for UnsafeMry {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_unit()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for UnsafeMry {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        d.deserialize_unit(serde::de::IgnoredAny)
+            .map(|_| Self::default())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cmp::Ordering;
+    use std::collections::HashSet;
+
+    use crate::unsafe_mocks::matcher::UnsafeMatcher;
+    use crate::unsafe_mocks::mock::UnsafeMock;
+
+    use super::*;
+
+    #[test]
+    fn mry_unique() {
+        let mut mry1 = UnsafeMry::default();
+        let mry2 = UnsafeMry::default();
+        assert_ne!(mry1.generate().id, mry2.id);
+    }
+
+    #[test]
+    fn mry_default_is_none() {
+        assert!(UnsafeMry::default().mocks.is_none());
+    }
+
+    #[test]
+    fn mry_always_equal() {
+        assert_eq!(*UnsafeMry::default().generate(), UnsafeMry::default());
+    }
+
+    #[test]
+    fn mry_always_equal_ord() {
+        assert_eq!(
+            UnsafeMry::default().cmp(UnsafeMry::default().generate()),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn mry_always_equal_partial_ord() {
+        assert_eq!(
+            UnsafeMry::default().partial_cmp(&UnsafeMry::default()),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn mry_hash_returns_consistent_value() {
+        #[allow(clippy::mutable_key_type)]
+        let mut set = HashSet::new();
+        set.insert(UnsafeMry::default());
+        set.insert(UnsafeMry::default());
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn generate_create_mock() {
+        let mut mry = UnsafeMry::default();
+        assert!(mry.mocks.is_none());
+        mry.generate();
+        assert!(mry.mocks.is_some());
+    }
+
+    #[test]
+    fn generate_does_not_overwrite() {
+        let mut mry = UnsafeMry::default();
+        mry.generate();
+        mry.mocks
+            .as_ref()
+            .unwrap()
+            .borrow_mut()
+            .insert(TypeId::of::<usize>(), UnsafeMock::<usize, usize>::new(""));
+        mry.generate();
+        assert_eq!(mry.mocks.unwrap().borrow().mock_objects.len(), 1);
+    }
+
+    #[test]
+    fn clone() {
+        let mut mry = UnsafeMry::default();
+        mry.generate();
+        mry.mocks
+            .as_ref()
+            .unwrap()
+            .borrow_mut()
+            .insert(TypeId::of::<usize>(), UnsafeMock::<usize, usize>::new(""));
+
+        assert_eq!(mry.clone().mocks.unwrap().borrow().mock_objects.len(), 1);
+    }
+
+    #[test]
+    fn inner_called_returns_none_when_no_mocks() {
+        let mry = UnsafeMry::default();
+
+        assert_eq!(
+            mry.record_call_and_find_mock_output::<u8, u16>(TypeId::of::<usize>(), "name", 1u8),
+            None
+        );
+    }
+
+    #[test]
+    fn inner_called_forwards_to_mock() {
+        let mut mry = UnsafeMry::default();
+
+        mry.mocks()
+            .borrow_mut()
+            .get_mut_or_create(TypeId::of::<usize>(), "name")
+            .returns(UnsafeMatcher::new_eq(1u8).wrapped(), 1u8);
+
+        assert_eq!(
+            mry.record_call_and_find_mock_output::<u8, u8>(TypeId::of::<usize>(), "name", 1u8),
+            Some(1u8)
+        );
+    }
+}

--- a/mry/src/unsafe_mocks/rule.rs
+++ b/mry/src/unsafe_mocks/rule.rs
@@ -1,0 +1,19 @@
+use std::{cell::RefCell, rc::Rc};
+
+use crate::Output;
+
+use super::{behavior::UnsafeBehavior, matcher::UnsafeMatcher};
+
+pub(crate) struct UnsafeRule<I, O> {
+    pub matcher: Rc<RefCell<UnsafeMatcher<I>>>,
+    pub behavior: UnsafeBehavior<I, O>,
+}
+
+impl<I, O> UnsafeRule<I, O> {
+    pub fn matches(&self, input: &I) -> bool {
+        self.matcher.borrow().matches(input)
+    }
+    pub fn call_behavior(&mut self, input: &I) -> Output<O> {
+        self.behavior.called(input)
+    }
+}

--- a/mry/src/unsafe_mocks/static_mocks.rs
+++ b/mry/src/unsafe_mocks/static_mocks.rs
@@ -1,0 +1,412 @@
+use std::{any::TypeId, cell::RefCell, collections::HashMap, ops::Deref, rc::Rc};
+
+use super::{
+    mock::UnsafeMock,
+    mockable::{UnsafeMockableArg, UnsafeMockableRet},
+    mocks::{UnsafeMockGetter, UnsafeMocks},
+};
+
+thread_local! {
+    pub static STATIC_UNSAFE_MOCKS: Rc<RefCell<UnsafeStaticMocks>> = Rc::new(RefCell::new(UnsafeStaticMocks::default()));
+}
+
+thread_local! {
+    pub static STATIC_UNSAFE_MOCK_LOCKS: RefCell<HashMap<TypeId, Rc<RefCell<()>>>> = RefCell::new(HashMap::new());
+}
+
+#[doc(hidden)]
+pub fn get_static_mocks() -> Rc<RefCell<UnsafeStaticMocks>> {
+    STATIC_UNSAFE_MOCKS.with(Clone::clone)
+}
+
+#[doc(hidden)]
+pub fn static_record_call_and_find_mock_output<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+    key: TypeId,
+    name: &'static str,
+    input: I,
+) -> Option<O> {
+    STATIC_UNSAFE_MOCKS.with(|mocks| {
+        mocks
+            .borrow_mut()
+            .record_call_and_find_mock_output(key, name, input)
+    })
+}
+
+#[doc(hidden)]
+pub struct UnsafeStaticMockCell {
+    pub key: TypeId,
+    pub name: String,
+    pub refcell: Rc<RefCell<()>>,
+}
+
+#[doc(hidden)]
+pub struct UnsafeStaticMockLock<'a> {
+    pub key: TypeId,
+    pub name: String,
+    pub lock: Box<dyn Deref<Target = ()> + 'a>,
+}
+
+impl Drop for UnsafeStaticMockLock<'_> {
+    fn drop(&mut self) {
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        if mocks.borrow_mut().0.remove(&self.key).is_none() {
+            panic!(
+                "{} is locked but no used. Remove {} from mry::lock",
+                self.name, self.name
+            );
+        };
+    }
+}
+
+#[doc(hidden)]
+#[derive(Default)]
+pub struct UnsafeStaticMocks(UnsafeMocks);
+
+fn check_locked(key: &TypeId) -> bool {
+    STATIC_UNSAFE_MOCK_LOCKS.with(|locks| {
+        locks
+            .borrow()
+            .get(key)
+            .map(|lock| lock.try_borrow_mut().is_err())
+            .unwrap_or(false)
+    })
+}
+
+impl<I: UnsafeMockableArg, O: UnsafeMockableRet> UnsafeMockGetter<I, O> for UnsafeStaticMocks {
+    fn get(&self, key: &TypeId, name: &'static str) -> Option<&UnsafeMock<I, O>> {
+        if !check_locked(key) {
+            panic!(
+                "the lock of `{name}` is not acquired. Try `#[mry::lock({name})]`",
+                name = name
+            );
+        }
+        self.0.get(key, name)
+    }
+
+    fn get_mut_or_create(&mut self, key: TypeId, name: &'static str) -> &mut UnsafeMock<I, O> {
+        if !check_locked(&key) {
+            panic!(
+                "the lock of `{name}` is not acquired. Try `#[mry::lock({name})]`",
+                name = name
+            );
+        }
+        self.0.get_mut_or_create(key, name)
+    }
+}
+
+impl UnsafeStaticMocks {
+    pub fn record_call_and_find_mock_output<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        &mut self,
+        key: TypeId,
+        name: &'static str,
+        input: I,
+    ) -> Option<O> {
+        if check_locked(&key) {
+            self.0.record_call_and_find_mock_output(key, name, input)
+        } else {
+            None
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn __mutexes(mut keys: Vec<(TypeId, String)>) -> Vec<UnsafeStaticMockCell> {
+    // Prevent deadlock by sorting the keys.
+    keys.sort();
+    keys.into_iter()
+        .map(|(key, name)| UnsafeStaticMockCell {
+            key,
+            name,
+            refcell: STATIC_UNSAFE_MOCK_LOCKS.with(|locks| {
+                locks
+                    .borrow_mut()
+                    .entry(key)
+                    .or_insert(Rc::new(Default::default()))
+                    .clone()
+            }),
+        })
+        .collect()
+}
+
+#[doc(hidden)]
+pub fn __lock_and_run<T>(mut mutexes: Vec<UnsafeStaticMockCell>, function: fn() -> T) -> T {
+    if let Some(mutex) = mutexes.pop() {
+        let _lock = UnsafeStaticMockLock {
+            key: mutex.key,
+            name: mutex.name,
+            lock: Box::new(mutex.refcell.borrow_mut()),
+        };
+        __lock_and_run(mutexes, function)
+    } else {
+        function()
+    }
+}
+
+// #[doc(hidden)]
+// #[async_recursion(?Send)]
+// pub async fn __async_lock_and_run<T>(
+//     mut mutexes: Vec<StaticMockMutex>,
+//     function: fn() -> Pin<Box<dyn Future<Output = T>>>,
+// ) -> T {
+//     if let Some(mutex) = mutexes.pop() {
+//         let _lock = StaticMockLock {
+//             key: mutex.key,
+//             name: mutex.name,
+//             lock: Box::new(mutex.mutex.lock()),
+//         };
+//         __async_lock_and_run(mutexes, function).await
+//     } else {
+//         function().await
+//     }
+// }
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use crate::unsafe_mocks::matcher::UnsafeMatcher;
+
+    use super::*;
+
+    #[test]
+    fn returns_none_if_not_mocked() {
+        insert_lock(
+            returns_none_if_not_mocked.type_id(),
+            Rc::new(Default::default()),
+        );
+
+        assert_eq!(
+            STATIC_UNSAFE_MOCKS.with(|mocks| mocks
+                .borrow_mut()
+                .record_call_and_find_mock_output::<(), ()>(
+                    returns_none_if_not_mocked.type_id(),
+                    "meow",
+                    ()
+                )),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_some_if_mocked() {
+        let mut mocks = UnsafeMocks::default();
+        mocks
+            .get_mut_or_create(returns_some_if_mocked.type_id(), "meow")
+            .returns(UnsafeMatcher::new_eq(()).wrapped(), ());
+        let mut static_mocks = UnsafeStaticMocks(mocks);
+
+        let mutex: Rc<_> = Rc::new(RefCell::default());
+        let _lock = mutex.borrow_mut();
+
+        insert_lock(returns_some_if_mocked.type_id(), mutex.clone());
+
+        assert_eq!(
+            static_mocks.record_call_and_find_mock_output::<(), ()>(
+                returns_some_if_mocked.type_id(),
+                "meow",
+                ()
+            ),
+            Some(())
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "the lock of `meow` is not acquired.")]
+    fn panic_if_lock_is_not_created() {
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        UnsafeMockGetter::<(), ()>::get(
+            mocks.borrow().deref(),
+            &panic_if_lock_is_not_created.type_id(),
+            "meow",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "the lock of `meow` is not acquired.")]
+    fn panic_if_lock_is_not_created_mut() {
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        UnsafeMockGetter::<(), ()>::get_mut_or_create(
+            &mut mocks.borrow_mut(),
+            panic_if_lock_is_not_created_mut.type_id(),
+            "meow",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "the lock of `meow` is not acquired.")]
+    fn panic_if_lock_is_not_acquired() {
+        insert_lock(
+            panic_if_lock_is_not_acquired.type_id(),
+            Rc::new(Default::default()),
+        );
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        UnsafeMockGetter::<(), ()>::get(
+            mocks.borrow().deref(),
+            &panic_if_lock_is_not_acquired.type_id(),
+            "meow",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "the lock of `meow` is not acquired.")]
+    fn panic_if_lock_is_not_acquired_mut() {
+        insert_lock(
+            panic_if_lock_is_not_acquired_mut.type_id(),
+            Rc::new(Default::default()),
+        );
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        UnsafeMockGetter::<(), ()>::get_mut_or_create(
+            &mut mocks.borrow_mut(),
+            panic_if_lock_is_not_acquired_mut.type_id(),
+            "meow",
+        );
+    }
+
+    #[test]
+    fn delete_mock_when_lock_is_dropped() {
+        insert_mock(
+            delete_mock_when_lock_is_dropped.type_id(),
+            UnsafeMock::<usize, usize>::new(""),
+        );
+
+        drop(UnsafeStaticMockLock {
+            key: delete_mock_when_lock_is_dropped.type_id(),
+            name: "name".to_string(),
+            lock: Box::new(Box::new(())),
+        });
+
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+        assert!(UnsafeMockGetter::<usize, usize>::get(
+            &mocks.borrow().0,
+            &delete_mock_when_lock_is_dropped.type_id(),
+            "meow"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn __mutexes_creates_mutexes() {
+        let mutexes = __mutexes(vec![(
+            __mutexes_creates_mutexes.type_id(),
+            "name".to_string(),
+        )]);
+
+        assert_eq!(mutexes.len(), 1);
+        assert!(get_lock(__mutexes_creates_mutexes.type_id()).is_some());
+
+        cleanup_static_mock_lock(__mutexes_creates_mutexes.type_id());
+    }
+
+    #[test]
+    fn __mutexes_does_not_overwrite_mutexes() {
+        let mutexes = __mutexes(vec![(
+            __mutexes_does_not_overwrite_mutexes.type_id(),
+            "name".to_string(),
+        )]);
+
+        let _lock = mutexes[0].refcell.try_borrow_mut().unwrap();
+
+        let mutexes = __mutexes(vec![(
+            __mutexes_does_not_overwrite_mutexes.type_id(),
+            "name".to_string(),
+        )]);
+
+        assert!(mutexes[0].refcell.try_borrow_mut().is_err());
+
+        cleanup_static_mock_lock(__mutexes_creates_mutexes.type_id());
+    }
+
+    #[test]
+    fn __mutexes_sorts_keys() {
+        let mutexes = __mutexes(vec![
+            (0u16.type_id(), "name".to_string()),
+            (0u8.type_id(), "name".to_string()),
+            (0u32.type_id(), "name".to_string()),
+        ]);
+
+        let mut keys = vec![0u16.type_id(), 0u8.type_id(), 0u32.type_id()];
+        keys.sort();
+        assert_eq!(mutexes.iter().map(|m| m.key).collect::<Vec<_>>(), keys);
+    }
+
+    #[test]
+    fn __lock_and_run_just_runs() {
+        assert_eq!(__lock_and_run(vec![], || 42), 42)
+    }
+
+    #[test]
+    fn __lock_and_run_locks() {
+        fn a() {}
+        fn b() {}
+        insert_mock(a.type_id(), UnsafeMock::<usize, usize>::new(""));
+
+        insert_mock(b.type_id(), UnsafeMock::<usize, usize>::new(""));
+
+        let mutexes = __mutexes(vec![(a.type_id(), "a".into()), (b.type_id(), "b".into())]);
+        __lock_and_run(mutexes, || {
+            assert!(get_lock(a.type_id()).unwrap().try_borrow_mut().is_err());
+
+            assert!(get_lock(b.type_id()).unwrap().try_borrow_mut().is_err());
+        });
+    }
+
+    #[test]
+    fn __lock_and_run_delete_mocks_on_free() {
+        fn a() {}
+        fn b() {}
+        insert_mock(a.type_id(), UnsafeMock::<usize, usize>::new(""));
+
+        insert_mock(b.type_id(), UnsafeMock::<usize, usize>::new(""));
+
+        __lock_and_run(
+            __mutexes(vec![(a.type_id(), "a".into()), (b.type_id(), "b".into())]),
+            || {
+                let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+                assert!(UnsafeMockGetter::<usize, usize>::get(
+                    mocks.borrow().deref(),
+                    &a.type_id(),
+                    "a"
+                )
+                .is_some());
+
+                assert!(UnsafeMockGetter::<usize, usize>::get(
+                    mocks.borrow().deref(),
+                    &b.type_id(),
+                    "b"
+                )
+                .is_some());
+            },
+        );
+
+        let mocks = STATIC_UNSAFE_MOCKS.with(Clone::clone);
+
+        assert!(
+            UnsafeMockGetter::<usize, usize>::get(&mocks.borrow().0, &a.type_id(), "a").is_none()
+        );
+
+        assert!(
+            UnsafeMockGetter::<usize, usize>::get(&mocks.borrow().0, &b.type_id(), "b").is_none()
+        );
+    }
+
+    fn insert_mock<I: UnsafeMockableArg, O: UnsafeMockableRet>(
+        key: TypeId,
+        mock: UnsafeMock<I, O>,
+    ) {
+        STATIC_UNSAFE_MOCKS.with(|mocks| mocks.borrow_mut().0.insert(key, mock));
+    }
+
+    fn insert_lock(key: TypeId, lock: Rc<RefCell<()>>) {
+        STATIC_UNSAFE_MOCK_LOCKS.with(|locks| {
+            locks.borrow_mut().insert(key, lock);
+        });
+    }
+
+    fn get_lock(key: TypeId) -> Option<Rc<RefCell<()>>> {
+        STATIC_UNSAFE_MOCK_LOCKS.with(|locks| locks.borrow().get(&key).cloned())
+    }
+
+    fn cleanup_static_mock_lock(key: TypeId) {
+        STATIC_UNSAFE_MOCK_LOCKS.with(|locks| locks.borrow_mut().remove(&key));
+    }
+}

--- a/mry_macros/src/create_behaviors.rs
+++ b/mry_macros/src/create_behaviors.rs
@@ -41,3 +41,41 @@ pub fn create() -> TokenStream {
     });
     quote![#(#items)*]
 }
+
+pub fn unsafe_create() -> TokenStream {
+    let items = (0..=MAX_ARGUMENT_COUNT).map(|nargs| {
+        let (args, types): (Vec<_>, Vec<_>) = (1..=nargs)
+            .map(|i| {
+                let name = format!("Arg{i}");
+                (
+                    Ident::new(&name.to_lowercase(), Span::call_site()),
+                    Ident::new(&name, Span::call_site()),
+                )
+            })
+            .unzip();
+        let behavior_name = Ident::new(&format!("UnsafeBehavior{}", args.len()), Span::call_site());
+        quote! {
+            #[doc(hidden)]
+            pub struct #behavior_name<I, O>(Box<dyn FnMut(I) -> O + 'static>);
+
+            impl<Fn, O, #(#types),*> From<Fn> for #behavior_name<(#(#types,)*), O>
+            where
+                Fn: FnMut(#(#types),*) -> O + 'static,
+            {
+                fn from(mut function: Fn) -> Self {
+                    #behavior_name(Box::new(move |(#(#args,)*)| function(#(#args),*)))
+                }
+            }
+
+            impl<I: Clone, O> Into<UnsafeBehavior<I, O>> for #behavior_name<I, O> {
+                fn into(self) -> UnsafeBehavior<I, O> {
+                    UnsafeBehavior::Function {
+                        clone: Clone::clone,
+                        call: self.0,
+                    }
+                }
+            }
+        }
+    });
+    quote![#(#items)*]
+}

--- a/mry_macros/src/create_matchers.rs
+++ b/mry_macros/src/create_matchers.rs
@@ -39,3 +39,42 @@ pub(crate) fn create() -> TokenStream {
     });
     quote![#(#items)*]
 }
+
+pub(crate) fn unsafe_create() -> TokenStream {
+    let items = (0..=MAX_ARGUMENT_COUNT).map(|nargs| {
+        let (args, types): (Vec<_>, Vec<_>) = (1..=nargs)
+            .map(|i| {
+                let name = format!("Arg{i}");
+                (
+                    Ident::new(&name.to_lowercase(), Span::call_site()),
+                    Ident::new(&name, Span::call_site()),
+                )
+            })
+            .unzip();
+        let matchers: Vec<_> = types
+            .iter()
+            .map(|ty| quote![UnsafeArgMatcher<#ty>])
+            .collect();
+        let trait_bounds: Vec<_> = types.iter().map(|ty| quote![#ty: 'static]).collect();
+        let matchers = quote![#(#matchers,)*];
+        let matches = args.iter().enumerate().map(|(index, arg)| {
+            let index = Index::from(index);
+            quote![self.#index.matches(#arg)]
+        });
+        let args = quote![#(#args,)*];
+        quote! {
+            impl<#(#trait_bounds),*> UnsafeMatch<(#(#types,)*)> for (#matchers) {
+                fn matches(&self, (#args): &(#(#types,)*)) -> bool {
+                    #(#matches &&)* true
+                }
+            }
+
+            impl<#(#trait_bounds),*> From<(#matchers)> for UnsafeMatcher<(#(#types,)*)> {
+                fn from((#args): (#matchers)) -> Self {
+                    Self(Box::new((#args)))
+                }
+            }
+        }
+    });
+    quote![#(#items)*]
+}

--- a/mry_macros/src/item_fn.rs
+++ b/mry_macros/src/item_fn.rs
@@ -22,6 +22,24 @@ pub(crate) fn transform(input: ItemFn) -> TokenStream {
     }
 }
 
+pub(crate) fn unsafe_transform(input: ItemFn) -> TokenStream {
+    let (original, mock) = method::unsafe_transform(
+        quote![mry::unsafe_mocks::get_static_mocks()],
+        Default::default(),
+        "",
+        quote![mry::unsafe_mocks::static_record_call_and_find_mock_output],
+        Some(&input.vis),
+        &input.attrs,
+        &input.sig,
+        &input.block.to_token_stream(),
+    );
+
+    quote! {
+        #original
+        #mock
+    }
+}
+
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;

--- a/mry_macros/src/item_struct.rs
+++ b/mry_macros/src/item_struct.rs
@@ -68,6 +68,70 @@ pub(crate) fn transform(input: ItemStruct) -> TokenStream {
     }
 }
 
+pub(crate) fn unsafe_transform(input: ItemStruct) -> TokenStream {
+    let vis = &input.vis;
+    let struct_name = &input.ident;
+
+    let serde_skip_or_blank = if input.attrs.iter().any(|attr| {
+        if !attr.path().is_ident("derive") {
+            return false;
+        }
+        attr.meta
+            .require_list()
+            .unwrap()
+            .tokens
+            .to_token_stream()
+            .into_iter()
+            .any(|token| {
+                if let TokenTree::Ident(ident) = token {
+                    ident == "Serialize" || ident == "Deserialize"
+                } else {
+                    false
+                }
+            })
+    }) {
+        quote!(#[serde(skip)])
+    } else {
+        TokenStream::default()
+    };
+
+    let attrs = &input.attrs;
+    let struct_fields = input
+        .fields
+        .iter()
+        .map(|field| {
+            let attrs = field.attrs.clone();
+            let name = field.ident.as_ref().unwrap();
+            let ty = &field.ty;
+            let vis = &field.vis;
+            quote! {
+                #(#attrs)*
+                #vis #name: #ty
+            }
+        })
+        .collect::<Vec<_>>();
+    let struct_field_names = input
+        .fields
+        .iter()
+        .map(|field| &field.ident)
+        .collect::<Vec<_>>();
+    let generics = &input.generics;
+    let comma_for_fields = if struct_field_names.is_empty() {
+        None
+    } else {
+        Some(quote![,])
+    };
+
+    quote! {
+        #(#attrs)*
+        #vis struct #struct_name #generics {
+            #(#struct_fields),*#comma_for_fields
+            #serde_skip_or_blank
+            pub mry: mry::unsafe_mocks::UnsafeMry,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;

--- a/mry_macros/src/item_trait.rs
+++ b/mry_macros/src/item_trait.rs
@@ -85,6 +85,87 @@ pub(crate) fn transform(input: ItemTrait) -> TokenStream {
     }
 }
 
+pub(crate) fn unsafe_transform(input: ItemTrait) -> TokenStream {
+    let async_trait_or_blank = if input.attrs.iter().any(|attr| {
+        attr.path()
+            .segments
+            .iter()
+            .any(|segment| segment.ident == "async_trait")
+    }) {
+        quote!(#[async_trait::async_trait])
+    } else {
+        TokenStream::default()
+    };
+
+    let generics = &input.generics;
+    let trait_ident = &input.ident;
+    let mry_ident = Ident::new(&format!("UnsafeMock{}", &input.ident), Span::call_site());
+    let vis = &input.vis;
+    let panic_message = format!("mock not found for {}", trait_ident);
+    let (items, impl_items): (Vec<_>, Vec<_>) = input
+        .items
+        .iter()
+        .map(|item| match item {
+            syn::TraitItem::Fn(method) => {
+                let method_prefix = quote![<#mry_ident as #trait_ident>::];
+                let body = &method
+                    .default
+                    .as_ref()
+                    .map(|default| default.to_token_stream())
+                    .unwrap_or(quote![panic!(#panic_message)]);
+                if method.sig.receiver().is_none() {
+                    method::unsafe_transform(
+                        quote![mry::unsafe_mocks::get_static_mocks()],
+                        method_prefix,
+                        &format!("<{} as {}>::", mry_ident, trait_ident),
+                        quote![mry::unsafe_mocks::static_record_call_and_find_mock_output],
+                        None,
+                        &method.attrs,
+                        &method.sig,
+                        body,
+                    )
+                } else {
+                    method::unsafe_transform(
+                        quote![self.mry.mocks()],
+                        method_prefix,
+                        &(trait_ident.to_string() + "::"),
+                        quote![self.mry.record_call_and_find_mock_output],
+                        None,
+                        &method.attrs,
+                        &method.sig,
+                        body,
+                    )
+                }
+            }
+            _item => todo!(),
+        })
+        .unzip();
+
+    quote! {
+        #input
+
+        // This cfg(debug_assertions) is needed because `panic!` with return position impl
+        // trait is not supported yet in rustc. It is problem with using
+        // `trait_variant::make` macro that desugars `async fn`.
+        // See https://github.com/rust-lang/rust/issues/35121
+        #[cfg(debug_assertions)]
+        #[derive(Default, Clone, Debug)]
+        #vis struct #mry_ident {
+            pub mry: mry::unsafe_mocks::UnsafeMry,
+        }
+        #[cfg(debug_assertions)]
+        #async_trait_or_blank
+        impl #generics #trait_ident for #mry_ident {
+            #(#items)*
+        }
+
+        #[cfg(debug_assertions)]
+        impl #mry_ident {
+            #(#impl_items)*
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;

--- a/mry_macros/src/lib.rs
+++ b/mry_macros/src/lib.rs
@@ -105,3 +105,74 @@ pub fn m(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     m.visit_file_mut(&mut parse2(input.into()).unwrap());
     m.0.into()
 }
+
+#[proc_macro]
+pub fn unsafe_create_behaviors(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    create_behaviors::unsafe_create().into()
+}
+
+#[proc_macro]
+pub fn unsafe_create_matchers(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    create_matchers::unsafe_create().into()
+}
+
+#[proc_macro_attribute]
+pub fn unsafe_mry(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let attr = MryAttr::from_list(&NestedMeta::parse_meta_list(attr.into()).unwrap()).unwrap();
+    match parse(input.clone())
+        .map(TargetItem::Struct)
+        .or_else(|_| parse(input.clone()).map(TargetItem::Impl))
+        .or_else(|_| parse(input.clone()).map(TargetItem::Trait))
+        .or_else(|_| parse(input.clone()).map(TargetItem::Fn))
+    {
+        Ok(target) => {
+            let token_stream = match target {
+                TargetItem::Struct(target) => item_struct::unsafe_transform(target),
+                TargetItem::Impl(target) => item_impl::unsafe_transform(target),
+                TargetItem::Trait(target) => item_trait::unsafe_transform(target),
+                TargetItem::Fn(target) => item_fn::unsafe_transform(target),
+            };
+            if attr.debug.is_present() {
+                println!("{}", token_stream);
+            }
+            token_stream.into()
+        }
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn unsafe_lock(
+    attribute: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    lock::unsafe_transform(
+        parse_macro_input!(attribute as LockPaths),
+        parse_macro_input!(input as ItemFn),
+    )
+    .into()
+}
+
+struct UnsafeM(TokenStream);
+
+impl VisitMut for UnsafeM {
+    fn visit_item_trait_mut(&mut self, i: &mut ItemTrait) {
+        item_trait::unsafe_transform(i.clone()).to_tokens(&mut self.0)
+    }
+    fn visit_item_struct_mut(&mut self, i: &mut ItemStruct) {
+        item_struct::unsafe_transform(i.clone()).to_tokens(&mut self.0)
+    }
+    fn visit_item_impl_mut(&mut self, i: &mut ItemImpl) {
+        item_impl::unsafe_transform(i.clone()).to_tokens(&mut self.0)
+    }
+}
+
+#[proc_macro]
+pub fn unsafe_m(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mut m = UnsafeM(TokenStream::default());
+    m.visit_file_mut(&mut parse2(input.into()).unwrap());
+    m.0.into()
+}


### PR DESCRIPTION
Hi,
you have created an amazing mocking crate, and the approach is really smart from what I understood so far.

Being able to mock specific functions is really important for the code I currently write,
because it essentially is ported C code without any traits.
Unfortunately, porting C code requires at the first stage to use unsafe code and raw pointers.
Your current approach enforces a `Send` bound, which is not implemented for raw pointers.

To workaround the `Send` bound, I copied every code that was affected into the `unsafe_mocks` module and adapted the types and functions accordingly. The usage remains identical, just the macros have `unsafe_` as prefix. e.g. `unsafe_lock`, `unsafe_mry`

Instead of `Arc<Mutex<T>>`, I went with `Rc<RefCell<T>>` to have thread local interior mutability. This has the tradeoff, that multithreaded code or running tests in parallel might crash or not work as intended. This was acceptable for me, because the ported code requires some static mutables and runs on a single core embedded device. To get the same single thread behavior during testing, I set `-- --test-threads=1` as option when calling `cargo test`.

Currently, the code is mostly duplicated and I would like to reduce this so changes must not be mirrored for the safe and unsafe variants.

Would you be open to merge this PR once duplication is reduced to add the possibility to mock raw pointer types like `*mut T` and `*const T`? If you have a better idea to support raw pointer types in your current implementation please let me know 🙂 